### PR TITLE
Print STDERR When Running Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ The script **must** exit with a zero exit code to be considered successful. Exit
 
 Peruse [the examples](./examples) for a better understanding of what to do and contribute your own if you've done something noteworthy!
 
+Any data sent to `STDERR` will be printed to your terminal after the command runs.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/examples/nextyear
+++ b/examples/nextyear
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+require 'pathname'
+
+TICKETS = {
+  'workarea-commerce/workarea-address-verification' => 'WEBADDVER-4',
+  'workarea-commerce/workarea-stripe' => 'STRIPE-2',
+  'workarea-commerce/workarea-quotes' => 'QUOTES-3',
+  'workarea-commerce/workarea-oms' => 'OMS-5',
+  # 'workarea-commerce/workarea-global-e' => 'GLOBALE-3',
+  'workarea-commerce/workarea-gift-cards' => 'GIFTCARDS-6',
+  'workarea-commerce/workarea-forter' => 'FORTER-2',
+  'workarea-commerce/workarea-bopus' => 'BOPUS-3',
+  'workarea-commerce/workarea-payware-connect' => 'PAYWARE-1'
+}
+
+path, repo, _branch = ARGV
+plugin = Pathname.new(path)
+ticket = TICKETS[repo]
+@changed = false
+
+plugin.glob('test/**/*.{rb,decorator}').each do |test|
+  fixed = test.read.to_s.gsub(/2020,/, 'next_year,')
+                        .gsub(/'2020'/, 'next_year.to_s')
+                        .gsub(/"2020",/, 'next_year.to_s,')
+  @changed = fixed != test.read.to_s
+
+  test.write(fixed)
+end
+
+gemfile = plugin.join('Gemfile')
+gemfile.write(gemfile.read.to_s.gsub(/:master/, "'v3.5-stable'"))
+
+STDERR.puts "Ticket Not Found For Repo '#{repo}'" if ticket.nil? && @changed
+
+puts <<~COMMIT_MESSAGE
+Fix Tests for 2020
+
+Update all tests so that they no longer depend on the year 2020 as an
+expiration year. Instead, use the `next_year` method provided by Workarea.
+
+#{ticket}
+COMMIT_MESSAGE

--- a/lib/codeslave/cli.rb
+++ b/lib/codeslave/cli.rb
@@ -75,6 +75,8 @@ module Codeslave
               [@script_path, repo.clone_dir, repo.name, branch].join(' ')
             )
 
+            say script_result[:stderr], :red if script_result[:stderr].present?
+
             if script_result[:status].success? && !repo.has_changed?
               say 'SCRIPT SUCCEEDED BUT NO CHANGES TO COMMIT!', color: :yellow
               next


### PR DESCRIPTION
The `STDERR` response from the command is useful when you're trying to
debug your script. This change prints that message to the shell
regardless of the script's status.